### PR TITLE
Update OS Project roles information

### DIFF
--- a/content_development/MAIN.md
+++ b/content_development/MAIN.md
@@ -154,13 +154,14 @@ These definitions have now become widely adopted, both by international governme
 
 ### For individual projects
 
-A typical open source project has the following types formal roles:
+A typical open source project has the following types of formal roles:
 
 - **Author**: It is the  person that created the project
 - **Owner**: The person/s who has administrative ownership over the organization or repository 
 - **Maintainers**: Contributors who are responsible for driving the vision and managing the organizational aspects of the project. (They may also be authors or owners of the project.)
 - **Contributors**: The user that has already contributed to the project.
 - **Community Members**: People who use the project. They might be active in conversations, create new issues or express their opinion on the future project improvements.
+
 Typically, roles are made public through either the `README` file, a Contributors file, or a separate team page for the project.
 
 <br/>

--- a/content_development/MAIN.md
+++ b/content_development/MAIN.md
@@ -154,14 +154,13 @@ These definitions have now become widely adopted, both by international governme
 
 ### For individual projects
 
-Within OSS projects, there are typically three main formal roles:
+A typical open source project has the following types formal roles:
 
-* **Maintainer**;
-* **Contributor**; and
-* **Committer**.
-
-A **maintainer** is a user with 'commit' access to implement suggested changes to the project. They have responsibility for the direction and improvement of the project. A **contributor** is someone who directly adds value to the project through issue resolution, code writing, or even external activities such as communications and event organisation. A **committer** is someone who can make 'commits' to the project (see [Task 1](https://github.com/OpenScienceMOOC/Module-5-Open-Research-Software-and-Open-Source/blob/master/content_development/Task_1.md)).
-
+- **Author**: It is the  person that created the project
+- **Owner**: The person/s who has administrative ownership over the organization or repository 
+- **Maintainers**: Contributors who are responsible for driving the vision and managing the organizational aspects of the project. (They may also be authors or owners of the project.)
+- **Contributors**: The user that has already contributed to the project.
+- **Community Members**: People who use the project. They might be active in conversations, create new issues or express their opinion on the future project improvements.
 Typically, roles are made public through either the `README` file, a Contributors file, or a separate team page for the project.
 
 <br/>


### PR DESCRIPTION
This PR adds and refactor the information about the open source project roles with the "official roles" from GitHub.